### PR TITLE
debug redraw when dx1 is not 0

### DIFF
--- a/st7920.py
+++ b/st7920.py
@@ -131,4 +131,4 @@ class ST7920:
 	def redraw(self, dx1=0, dy1=0, dx2=127, dy2=63):
 		for i in range(dy1, dy2+1):
 			self.send(0,0,[0x80 + i%32, 0x80 + ((dx1/16) + (8 if i>=32 else 0))]) # set address
-			self.send(1,0,self.fbuff[i][dx1/16:(dx2/8)+1])
+			self.send(1,0,self.fbuff[i][dx1/8:(dx2/8)+1])


### PR DESCRIPTION
Hi! Thank you for this library, it has helped us a lot. I believe there's a small bug when trying to redraw the screen with horizontal address other than 0. 